### PR TITLE
support tab-size prefix

### DIFF
--- a/src/Prefixer.js
+++ b/src/Prefixer.js
@@ -21,6 +21,9 @@ export function prefix (value, length, children) {
 		// background-clip, columns, column-(count|fill|gap|rule|rule-color|rule-style|rule-width|span|width)
 		case 4215: case 6389: case 5109: case 5365: case 5621: case 3829:
 			return WEBKIT + value + value
+		// tab-size
+		case 4789:
+			return MOZ + value + value
 		// appearance, user-select, transform, hyphens, text-size-adjust
 		case 5349: case 4246: case 4810: case 6968: case 2756:
 			return WEBKIT + value + MOZ + value + MS + value + value

--- a/test/Prefixer.js
+++ b/test/Prefixer.js
@@ -252,4 +252,8 @@ describe('Prefixer', () => {
 		expect(prefix(`scroll-margin-bottom:0;`, 20)).to.equal([`scroll-snap-margin-bottom:0;`, `scroll-margin-bottom:0;`].join(''))
 		expect(prefix(`scroll-margin-left:0;`, 18)).to.equal([`scroll-snap-margin-left:0;`, `scroll-margin-left:0;`].join(''))
 	})
+
+	test('tab-size', () => {
+		expect(prefix(`tab-size:1;`, 8)).to.equal([`-moz-tab-size:1;`, `tab-size:1;`].join(''))
+	})
 })


### PR DESCRIPTION
Add prefix support with `tab-size`. It is a `-moz-` only prefix.