### PR TITLE
fix: support `value !important;`

### DIFF
--- a/src/Prefixer.js
+++ b/src/Prefixer.js
@@ -105,20 +105,18 @@ export function prefix (value, length, children) {
 			return replace(value, /(.+?):(\d+)(\s*\/\s*(span)?\s*(\d+))?(.*)/, function (_, a, b, c, d, e, f) { return (MS + a + ':' + b + f) + (c ? (MS + a + '-span:' + (d ? e : +e - +b)) + f : '') + value })
 		// position: sticky
 		case 4949:
-			// (s)ticky?
-			if (charat(value, length + 1) !== 115)
-				break
+			// stick(y)?
+			if (charat(value, length + 6) === 121)
+				return replace(value, ':', ':' + WEBKIT) + value
+			break
 		// display: (flex|inline-flex|grid|inline-grid)
 		case 6444:
-			switch (charat(value, strlen(value) - 3 - (~indexof(value, ' !important') ? 11 : ~indexof(value, '!important') && 10))) {
-				// stic(k)y
-				case 107:
-					return replace(value, ':', ':' + WEBKIT) + value
-				// (inline-)?fl(e)x
-				case 101:
-					return replace(value, /(.+:)([^;\s!]+)(;|\s?!.+)?/, '$1' + WEBKIT + (charat(value, 14) === 45 ? 'inline-' : '') + 'box$3' + '$1' + WEBKIT + '$2$3' + '$1' + MS + '$2box$3') + value
-				// (inline-)?grid
-				case 105:
+			switch (charat(value, 14) === 45 ? charat(value, 18) : charat(value, 11)) {
+				// (inline-)?fle(x)
+				case 120:
+					return replace(value, /(.+:)([^;\s!]+)(;|(\s+)?!.+)?/, '$1' + WEBKIT + (charat(value, 14) === 45 ? 'inline-' : '') + 'box$3' + '$1' + WEBKIT + '$2$3' + '$1' + MS + '$2box$3') + value
+				// (inline-)?gri(d)
+				case 100:
 					return replace(value, ':', ':' + MS) + value
 			}
 			break

--- a/src/Prefixer.js
+++ b/src/Prefixer.js
@@ -111,7 +111,7 @@ export function prefix (value, length, children) {
 			break
 		// display: (flex|inline-flex|grid|inline-grid)
 		case 6444:
-			switch (charat(value, 14) === 45 ? charat(value, 18) : charat(value, 11)) {
+			switch (charat(value, charat(value, 14) === 45 ? 18 : 11)) {
 				// (inline-)?fle(x)
 				case 120:
 					return replace(value, /(.+:)([^;\s!]+)(;|(\s+)?!.+)?/, '$1' + WEBKIT + (charat(value, 14) === 45 ? 'inline-' : '') + 'box$3' + '$1' + WEBKIT + '$2$3' + '$1' + MS + '$2box$3') + value

--- a/src/Prefixer.js
+++ b/src/Prefixer.js
@@ -110,13 +110,13 @@ export function prefix (value, length, children) {
 				break
 		// display: (flex|inline-flex|grid|inline-grid)
 		case 6444:
-			switch (charat(value, strlen(value) - 3 - (~indexof(value, '!important') && 10))) {
+			switch (charat(value, strlen(value) - 3 - (~indexof(value, ' !important') ? 11 : ~indexof(value, '!important') && 10))) {
 				// stic(k)y
 				case 107:
 					return replace(value, ':', ':' + WEBKIT) + value
 				// (inline-)?fl(e)x
 				case 101:
-					return replace(value, /(.+:)([^;!]+)(;|!.+)?/, '$1' + WEBKIT + (charat(value, 14) === 45 ? 'inline-' : '') + 'box$3' + '$1' + WEBKIT + '$2$3' + '$1' + MS + '$2box$3') + value
+					return replace(value, /(.+:)([^;\s!]+)(;|\s?!.+)?/, '$1' + WEBKIT + (charat(value, 14) === 45 ? 'inline-' : '') + 'box$3' + '$1' + WEBKIT + '$2$3' + '$1' + MS + '$2box$3') + value
 				// (inline-)?grid
 				case 105:
 					return replace(value, ':', ':' + MS) + value

--- a/test/Prefixer.js
+++ b/test/Prefixer.js
@@ -4,7 +4,7 @@ const globalCssValues = ['inherit', 'initial', 'unset', 'revert', 'revert-layer'
 
 describe('Prefixer', () => {
 	test('flex-box', () => {
-		globalCssValues.forEach(v => expect(prefix(`display:${v};`, 7)).to.equal([`display:${v};`].join()))
+		globalCssValues.concat(['block', 'inline', 'inline-block', 'flow-root', 'none', 'contents', 'table', 'table-row', 'list-item']).forEach(v => expect(prefix(`display:${v};`, 7)).to.equal([`display:${v};`].join()))
 
 		expect(prefix(`display:flex!important;`, 7)).to.equal([`display:-webkit-box!important;`, `display:-webkit-flex!important;`, `display:-ms-flexbox!important;`, `display:flex!important;`].join(''))
 		expect(prefix(`display:flex !important;`, 7)).to.equal([`display:-webkit-box !important;`, `display:-webkit-flex !important;`, `display:-ms-flexbox !important;`, `display:flex !important;`].join(''))

--- a/test/Prefixer.js
+++ b/test/Prefixer.js
@@ -8,6 +8,7 @@ describe('Prefixer', () => {
 
 		expect(prefix(`display:flex!important;`, 7)).to.equal([`display:-webkit-box!important;`, `display:-webkit-flex!important;`, `display:-ms-flexbox!important;`, `display:flex!important;`].join(''))
 		expect(prefix(`display:flex !important;`, 7)).to.equal([`display:-webkit-box !important;`, `display:-webkit-flex !important;`, `display:-ms-flexbox !important;`, `display:flex !important;`].join(''))
+		expect(prefix(`display:flex     !important;`, 7)).to.equal([`display:-webkit-box     !important;`, `display:-webkit-flex     !important;`, `display:-ms-flexbox     !important;`, `display:flex     !important;`].join(''))
 		expect(prefix(`display:inline-flex;`, 7)).to.equal([`display:-webkit-inline-box;`, `display:-webkit-inline-flex;`, `display:-ms-inline-flexbox;`, `display:inline-flex;`].join(''))
 		expect(prefix(`flex:inherit;`, 4)).to.equal([`-webkit-flex:inherit;`, `-ms-flex:inherit;`, `flex:inherit;`].join(''))
 		expect(prefix(`flex-grow:none;`, 9)).to.equal([`-webkit-box-flex:none;`, `-webkit-flex-grow:none;`, `-ms-flex-positive:none;`, `flex-grow:none;`].join(''))

--- a/test/Prefixer.js
+++ b/test/Prefixer.js
@@ -1,8 +1,11 @@
 import {compile, serialize, stringify, middleware, prefixer, prefix} from "../index.js"
 
+const globalCssValues = ['inherit', 'initial', 'unset', 'revert', 'revert-layer']
+
 describe('Prefixer', () => {
 	test('flex-box', () => {
-		expect(prefix(`display:block;`, 7)).to.equal(['display:block;'].join())
+		globalCssValues.forEach(v => expect(prefix(`display:${v};`, 7)).to.equal([`display:${v};`].join()))
+
 		expect(prefix(`display:flex!important;`, 7)).to.equal([`display:-webkit-box!important;`, `display:-webkit-flex!important;`, `display:-ms-flexbox!important;`, `display:flex!important;`].join(''))
 		expect(prefix(`display:flex !important;`, 7)).to.equal([`display:-webkit-box !important;`, `display:-webkit-flex !important;`, `display:-ms-flexbox !important;`, `display:flex !important;`].join(''))
 		expect(prefix(`display:inline-flex;`, 7)).to.equal([`display:-webkit-inline-box;`, `display:-webkit-inline-flex;`, `display:-ms-inline-flexbox;`, `display:inline-flex;`].join(''))
@@ -108,11 +111,7 @@ describe('Prefixer', () => {
 		expect(prefix(`position:static;`, 8)).to.equal([`position:static;`].join(''))
 		expect(prefix(`position:fixed;`, 8)).to.equal([`position:fixed;`].join(''))
 		expect(prefix(`position:absolute;`, 8)).to.equal([`position:absolute;`].join(''))
-		expect(prefix(`position:inherit;`, 8)).to.equal([`position:inherit;`].join(''))
-		expect(prefix(`position:initial;`, 8)).to.equal([`position:initial;`].join(''))
-		expect(prefix(`position:revert;`, 8)).to.equal([`position:revert;`].join(''))
-		expect(prefix(`position:revert-layer;`, 8)).to.equal([`position:revert-layer;`].join(''))
-		expect(prefix(`position:unset;`, 8)).to.equal([`position:unset;`].join(''))
+		globalCssValues.forEach(v => expect(prefix(`position:${v};`, 8)).to.equal([`position:${v};`].join()))
 
 		expect(prefix(`position:sticky;`, 8)).to.equal([`position:-webkit-sticky;`, `position:sticky;`].join(''))
 		expect(prefix(`position:sticky!important;`, 8)).to.equal([`position:-webkit-sticky!important;`, `position:sticky!important;`].join(''))

--- a/test/Prefixer.js
+++ b/test/Prefixer.js
@@ -4,6 +4,7 @@ describe('Prefixer', () => {
 	test('flex-box', () => {
 		expect(prefix(`display:block;`, 7)).to.equal(['display:block;'].join())
 		expect(prefix(`display:flex!important;`, 7)).to.equal([`display:-webkit-box!important;`, `display:-webkit-flex!important;`, `display:-ms-flexbox!important;`, `display:flex!important;`].join(''))
+		expect(prefix(`display:flex !important;`, 7)).to.equal([`display:-webkit-box !important;`, `display:-webkit-flex !important;`, `display:-ms-flexbox !important;`, `display:flex !important;`].join(''))
 		expect(prefix(`display:inline-flex;`, 7)).to.equal([`display:-webkit-inline-box;`, `display:-webkit-inline-flex;`, `display:-ms-inline-flexbox;`, `display:inline-flex;`].join(''))
 		expect(prefix(`flex:inherit;`, 4)).to.equal([`-webkit-flex:inherit;`, `-ms-flex:inherit;`, `flex:inherit;`].join(''))
 		expect(prefix(`flex-grow:none;`, 9)).to.equal([`-webkit-box-flex:none;`, `-webkit-flex-grow:none;`, `-ms-flex-positive:none;`, `flex-grow:none;`].join(''))
@@ -104,7 +105,19 @@ describe('Prefixer', () => {
 
 	test('position', () => {
 		expect(prefix(`position:relative;`, 8)).to.equal([`position:relative;`].join(''))
+		expect(prefix(`position:static;`, 8)).to.equal([`position:static;`].join(''))
+		expect(prefix(`position:fixed;`, 8)).to.equal([`position:fixed;`].join(''))
+		expect(prefix(`position:absolute;`, 8)).to.equal([`position:absolute;`].join(''))
+		expect(prefix(`position:inherit;`, 8)).to.equal([`position:inherit;`].join(''))
+		expect(prefix(`position:initial;`, 8)).to.equal([`position:initial;`].join(''))
+		expect(prefix(`position:revert;`, 8)).to.equal([`position:revert;`].join(''))
+		expect(prefix(`position:revert-layer;`, 8)).to.equal([`position:revert-layer;`].join(''))
+		expect(prefix(`position:unset;`, 8)).to.equal([`position:unset;`].join(''))
+
 		expect(prefix(`position:sticky;`, 8)).to.equal([`position:-webkit-sticky;`, `position:sticky;`].join(''))
+		expect(prefix(`position:sticky!important;`, 8)).to.equal([`position:-webkit-sticky!important;`, `position:sticky!important;`].join(''))
+		expect(prefix(`position:sticky !important;`, 8)).to.equal([`position:-webkit-sticky !important;`, `position:sticky !important;`].join(''))
+		expect(prefix(`position:sticky      !important;`, 8)).to.equal([`position:-webkit-sticky      !important;`, `position:sticky      !important;`].join(''))
 	})
 
 	test('color-adjust', () => {
@@ -191,6 +204,8 @@ describe('Prefixer', () => {
 	test('grid', () => {
 		expect(prefix('display:grid;', 7)).to.equal([`display:-ms-grid;`, `display:grid;`].join(''))
 		expect(prefix('display:inline-grid;', 7)).to.equal([`display:-ms-inline-grid;`, `display:inline-grid;`].join(''))
+		expect(prefix('display:inline-grid!important;', 7)).to.equal([`display:-ms-inline-grid!important;`, `display:inline-grid!important;`].join(''))
+		expect(prefix('display:inline-grid !important;', 7)).to.equal([`display:-ms-inline-grid !important;`, `display:inline-grid !important;`].join(''))
 		expect(prefix(`align-self:value;`, 10)).to.equal([`-webkit-align-self:value;`, `-ms-flex-item-align:value;`, `-ms-grid-row-align:value;`, `align-self:value;`].join(''))
 		expect(prefix(`align-self:safe center;`, 10)).to.equal([`-webkit-align-self:safe center;`, `-ms-flex-item-align:safe center;`, `-ms-grid-row-align:safe center;`, `align-self:safe center;`].join(''))
 		expect(prefix('align-self:stretch;', 10)).to.equal([`-webkit-align-self:stretch;`, `-ms-flex-item-align:stretch;`, `-ms-grid-row-align:stretch;`, `align-self:stretch;`].join(''))


### PR DESCRIPTION
Fix an edge case that `position:sticky!important` can be prefixed while `position:sticky !important` (a white space before `!important`) can not.