### PR TITLE
Expose `stylis` object globally on the docs site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,9 @@ div {
 		</div>
 		<script type=module>
 			import {compile, serialize, middleware, prefixer, stringify} from 'https://unpkg.com/stylis?module'
+			import * as stylis from 'https://unpkg.com/stylis?module'
+			
+			window.stylis = stylis
 
 			function tabbed (select, ranged, content) {
 				ranged.deleteContents()


### PR DESCRIPTION
It's quite useful for quick experiments at times - this kind of library object is often exposed on different doc sites