### PR TITLE
Update Parser.js

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -161,8 +161,10 @@ export function ruleset (value, root, parent, index, offset, rules, points, type
 	var rule = offset === 0 ? rules : ['']
 	var size = sizeof(rule)
 
-	for (var i = 0, j = 0, k = 0; i < index; ++i)
-		for (var x = 0, y = substr(value, post + 1, post = abs(j = points[i])), z = value; x < size; ++x)
+	for (var i = 0, k = 0; i < index; ++i)
+		var j = points[i]
+		var y = substr(value, post + 1, post = abs(j))
+		for (var x = 0, z = value; x < size; ++x)
 			if (z = trim(j > 0 ? rule[x] + ' ' + y : replace(y, /&\f/g, rule[x])))
 				props[k++] = z
 


### PR DESCRIPTION
Functionality is the same, but previous version would break when minified with the Google Closure Compiler.

(it ended up doing the equivalent of `var y = z = substr(...)`, therefore the if statement would always return false)