### PR TITLE
fix: webkit mask-composite values

### DIFF
--- a/src/Prefixer.js
+++ b/src/Prefixer.js
@@ -1,5 +1,5 @@
-import {MS, MOZ, WEBKIT} from './Enum.js'
-import {hash, charat, strlen, indexof, replace, substr, match} from './Utility.js'
+import { MOZ, MS, WEBKIT } from './Enum.js';
+import { charat, hash, indexof, match, replace, strlen, substr } from './Utility.js';
 
 /**
  * @param {string} value
@@ -16,11 +16,19 @@ export function prefix (value, length, children) {
 		case 5737: case 4201: case 3177: case 3433: case 1641: case 4457: case 2921:
 		// text-decoration, filter, clip-path, backface-visibility, column, box-decoration-break
 		case 5572: case 6356: case 5844: case 3191: case 6645: case 3005:
-		// mask, mask-image, mask-(mode|clip|size), mask-(repeat|origin), mask-position, mask-composite,
-		case 6391: case 5879: case 5623: case 6135: case 4599: case 4855:
 		// background-clip, columns, column-(count|fill|gap|rule|rule-color|rule-style|rule-width|span|width)
 		case 4215: case 6389: case 5109: case 5365: case 5621: case 3829:
+		// mask, mask-image, mask-(mode|clip|size), mask-(repeat|origin), mask-position
+		case 6391: case 5879: case 5623: case 6135: case 4599: 
 			return WEBKIT + value + value
+		// mask-composite
+		case 4855:
+			const webkitValue = value
+        .replaceAll("add", "source-over")
+        .replaceAll("substract", "source-out")
+        .replaceAll("intersect", "source-in")
+        .replaceAll("exclude", "xor");
+      return WEBKIT + webkitValue + value;
 		// tab-size
 		case 4789:
 			return MOZ + value + value


### PR DESCRIPTION
Fix for mask-composite prop values for webkit

Here are the changes:
```
'add' → 'source-over'
'substract' → 'source-out'
'intersect' → 'source-in'
'exclude' → 'xor'
```

Example for ```element.return```:
```
before fix (not working in webkit)
'-webkit-mask-composite: add,intersect;mask-composite: add,intersect;'  

after fix
'-webkit-mask-composite: source-over,source-in;mask-composite: add,intersect;'
```