### PR TITLE
test: add more unit test

### DIFF
--- a/test/Parser.js
+++ b/test/Parser.js
@@ -1259,5 +1259,11 @@ describe('Parser', () => {
         }
       `)
     ).to.equal(`@layer framework{@keyframes slide-left{from{margin-left:0;}to{margin-left:-100%;}}}`);
+
+  });
+
+  test('cascade @layer: empty braces', () => {
+    // `@layer base {}` should be parsed as `@layer base{}`. 
+    expect(stylis('', '@layer base')).to.equal(`@layer base{}`);
   });
 })


### PR DESCRIPTION
I'd like to report an issue (though I'm not entirely sure whether it's a bug or just user error).

I found an issue report on https://github.com/ant-design/ant-design/issues/51867.

After investigating, I traced it down to `stylis` having problems with parsing the `@layer` query.

Here's a minimal example:

```jsx
import { compile, serialize, stringify } from "stylis"

serialize(compile(`@layer base{}`), stringify) // should return `@layer base{}`
```

The expected output is `@layer base{}`, but it actually returns `@layer base`, missing the `{}` part.

I also tested `@emotion/styled`, and it works as expected.

<img width="1397" alt="image" src="https://github.com/user-attachments/assets/0f94e65a-224c-4d0f-8369-7d2775a43f73">


It seems like an edge case, and I believe it's a bug.

Thanks for your time. I hope this gets resolved soon.