### PR TITLE
add prefixing for text-align:match-parent

### DIFF
--- a/src/Prefixer.js
+++ b/src/Prefixer.js
@@ -139,6 +139,12 @@ export function prefix (value, length, children) {
 					return replace(value, ':', ':' + MS) + value
 			}
 			break
+		// text-align: match-parent
+		case 4292:
+			// match-parent
+			if (charat(value, length + 2) === 97)
+				return replace(value, ':', ':' + WEBKIT) + value
+			break
 		// scroll-margin, scroll-margin-(top|right|bottom|left)
 		case 5719: case 2647: case 2135: case 3927: case 2391:
 			return replace(value, 'scroll-', 'scroll-snap-') + value

--- a/test/Prefixer.js
+++ b/test/Prefixer.js
@@ -83,6 +83,7 @@ describe('Prefixer', () => {
 
 	test('text', () => {
 		expect(prefix(`text-align:left;`, 10)).to.equal([`text-align:left;`].join(''))
+		expect(prefix(`text-align:match-parent;`, 10)).to.equal([`text-align:-webkit-match-parent;`, `text-align:match-parent;`].join(''))
 		expect(prefix(`text-transform:none;`, 14)).to.equal([`text-transform:none;`].join(''))
 		expect(prefix(`text-shadow:none;`, 11)).to.equal([`text-shadow:none;`].join(''))
 		expect(prefix(`text-size-adjust:none;`, 16)).to.equal([`-webkit-text-size-adjust:none;`, `-moz-text-size-adjust:none;`, `-ms-text-size-adjust:none;`, `text-size-adjust:none;`].join(''))


### PR DESCRIPTION
The newer `text-align: match-parent` (supports RTL and BiDi use cases) is in need of prefixing for webkit based browsers.

See: https://developer.mozilla.org/en-US/docs/Web/CSS/text-align#browser_compatibility

P.S. github actions currently run against the ancient nodejs v11 and did not run correctly locally for me using a modern version of node. do you have any interest in a followup pr that modernizes things slightly? (mostly just removing the `esm` dev dependency and updating the github actions definition)