### PR TITLE
Update rollup-plugin-size version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
     "rollup": "1.28.0",
-    "rollup-plugin-size": "0.2.1",
+    "rollup-plugin-size": "0.3.0",
     "rollup-plugin-terser": "5.1.3",
     "stylis": "./"
   },


### PR DESCRIPTION
**Update rollup-plugin-size to 0.3.0 to address security vulnerability**

This PR updates the devDependency rollup-plugin-size from 0.2.1 to 0.3.0. The previous version depended on axios <0.30.0, which is vulnerable to CVE-2025-27152 (high severity). Upgrading to 0.3.0 removes the vulnerable axios version from the dependency tree and improves overall security. No breaking changes are expected, as rollup-plugin-size is only used for reporting bundle sizes during development.